### PR TITLE
fix(api-calls): get instance minor version before d2 init

### DIFF
--- a/app/src/messaging.js
+++ b/app/src/messaging.js
@@ -8,13 +8,15 @@ import { init, getUserSettings } from 'd2/lib/d2'
 import 'whatwg-fetch'
 
 import configI18n from './utils/configI18n'
+import getDhis2CoreVersion from './utils/getDhis2CoreVersion'
 
 const schemas = ['messageConversation']
 ;(async () => {
     const PRODUCTION = process.env.NODE_ENV === 'production'
     const baseUrl = PRODUCTION ? '..' : DHIS_CONFIG.baseUrl
+    const instanceVersion = await getDhis2CoreVersion(baseUrl)
     const dhisConfig = {
-        baseUrl: `${baseUrl}/api`,
+        baseUrl: `${baseUrl}/api/${instanceVersion.minor}`,
         headers: PRODUCTION ? null : null,
         schemas,
     }

--- a/app/src/utils/getDhis2CoreVersion.js
+++ b/app/src/utils/getDhis2CoreVersion.js
@@ -1,0 +1,14 @@
+import 'whatwg-fetch'
+import System from 'd2/lib/system/System'
+
+const fetchInit = {
+    method: 'GET',
+    credentials: 'include',
+}
+
+export default async function getDhis2CoreVersion(baseUrl) {
+    return fetch(`${baseUrl}/api/system/info`, fetchInit)
+        .then(response => response.json())
+        .then(info => System.parseVersionString(info.version))
+        .catch(error => console.error)
+}


### PR DESCRIPTION
This way we do one unversioned call to `/system/info`, and after that everything is versioned. I think it would be nice if the `getDhis2CoreVersion` would be part of d2.
Let me know what you think.