### PR TITLE
fix: allow hosting app on nested url

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,10 @@
+# By default CRA expects the app to be hosted at server root
+# this ensures that assets are looked up relative to where
+# index.html is served from
+# See also: https://facebook.github.io/create-react-app/docs/using-the-public-folder
+# and: https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables
+PUBLIC_URL="."
+
 # Authorization left empty intentionally for production
 REACT_APP_DHIS2_BASE_URL=".."
 REACT_APP_DHIS2_AUTHORIZATION=


### PR DESCRIPTION
CRA expects the app to be hosted at the server root. This uses a similar solution as the dashboards app to allow for example the play environment to host the app as well.

See: https://github.com/dhis2/dashboards-app/blob/master/package.json#L49