### PR TITLE
fix: assign users to messages in validation and ticket sections

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -94,14 +94,14 @@ export const updateMessageConversations = ({
                         messageType.id === 'VALIDATION_RESULT'
                     ) {
                         promise = api
-                            .addRecipients(
-                                value.map(value => ({
+                            .addRecipients({
+                                users: value.map(value => ({
                                     id: value,
                                 })),
-                                [],
-                                [],
-                                messageConversationId
-                            )
+                                userGroups: [],
+                                organisationUnits: [],
+                                messageConversationId,
+                            })
                             .then(() =>
                                 api.updateMessageConversationAssignee(
                                     messageConversationId,

--- a/src/components/Common/SuggestionField.jsx
+++ b/src/components/Common/SuggestionField.jsx
@@ -37,7 +37,7 @@ class SuggestionField extends Component {
                 feedbackRecipientsId,
                 searchOnlyUsers,
                 searchOnlyFeedbackRecipients,
-            } = this.state
+            } = this.props
 
             api.searchRecipients({
                 searchValue: input,


### PR DESCRIPTION
This is a regression from #29. The api function `api.addRecipients` now expects an object, but it was still being called with positional arguments from the action `updateMessageConversations`.