### PR TITLE
fix: provide an api-version to the app-runtime provider for v31.7

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,12 @@ import { render } from 'react-dom'
 import * as serviceWorker from './serviceWorker'
 import App from './components/App/App'
 import { init, getUserSettings } from 'd2/lib/d2'
-import configI18n from './utils/configI18n'
 import { CssReset } from '@dhis2/ui-core'
 import { Provider } from '@dhis2/app-runtime'
+
+import configI18n from './utils/configI18n'
+import { supportsUnversionedApiCalls } from './utils/helpers'
+
 import './index.css'
 import 'typeface-roboto'
 
@@ -19,12 +22,19 @@ const initApp = async () => {
     }
     const d2 = await init(dhisConfig)
     const userSettings = await getUserSettings()
+
+    const systemVersion = d2.system.version.minor
+    const providerApiVersion = supportsUnversionedApiCalls(systemVersion)
+        ? ''
+        : systemVersion
+
     configI18n(userSettings)
+
     render(
         <Provider
             config={{
                 baseUrl: REACT_APP_DHIS2_BASE_URL,
-                apiVersion: '',
+                apiVersion: providerApiVersion,
             }}
         >
             <CssReset />

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -38,3 +38,7 @@ export function debounce(fn, delay) {
 export function supportsAttachments(dhis2CoreVersion) {
     return dhis2CoreVersion > 30
 }
+
+export function supportsUnversionedApiCalls(dhis2CoreVersion) {
+    return dhis2CoreVersion > 31
+}


### PR DESCRIPTION
This should not be merged in before https://jira.dhis2.org/browse/DHIS2-8053 has been tested.