### PR TITLE
fix: switch to userLookup endpoint for version >= 2.35

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -42,3 +42,7 @@ export function supportsAttachments(dhis2CoreVersion) {
 export function supportsUnversionedApiCalls(dhis2CoreVersion) {
     return dhis2CoreVersion > 31
 }
+
+export function supportsUserLookupEndPoint(dhis2CoreVersion) {
+    return dhis2CoreVersion > 34
+}


### PR DESCRIPTION
V2.35 introduces the `userLookup` and `userLookup/feedbackRecipients` to query users in a more secure way. Since this app does feature toggling, I have some conditional code in place that calls the `users` endpoint in versions <2.35 and the new endpoint for versions >=2.35.