### PR TITLE
fix: don't use system path lib for joining URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "material-ui": "^0.20.0",
         "material-ui-chip-input": "^0.19.0",
         "material-ui-icons": "1.0.0-beta.36",
-        "path-browserify": "^1.0.1",
         "react-linkify": "^1.0.0-alpha",
         "react-redux": "^7.2.1",
         "react-router-dom": "^5.2.0",

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,4 +1,3 @@
-import path from 'path-browserify'
 import { pageSize } from '../constants/development.js'
 import createRecipientSearchQuery from '../utils/createRecipientSearchQuery.js'
 
@@ -338,12 +337,17 @@ export const addAttachment = attachment =>
         },
     })
 
+const joinPath = (...parts) => {
+    const realParts = parts.filter(part => !!part)
+    return realParts.map(part => part.replace(/^\/+|\/+$/g, '')).join('/')
+}
+
 export const downloadAttachment = (
     messageConversationId,
     messageId,
     attachmentId
 ) => {
-    const filePath = path.join(
+    const filePath = joinPath(
         engine.link.baseUrl,
         engine.link.apiPath,
         'messageConversations',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10525,11 +10525,6 @@ path-browserify@0.0.1:
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
   integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
 
-path-browserify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
-  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
-
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-10508

In https://github.com/dhis2/messaging-app/pull/287 I changed the way we join URL paths from `[...].join('/')` to `path.join(...)`. However, I failed to notice that `path` returns incorrect values when used on URLs as it is designed for system paths. For example, `path.join('http://example.com', '/example')` returns `http:/example.com/example` (note the single slash in the protocol).

I've removed `path-browserify` and I have replaced it with `joinPath` from [`@dhis2/ui`](https://github.com/dhis2/ui/blob/1c9d055e735f6e32706b91e4f75d8be6e6096860/packages/widgets/src/HeaderBar/joinPath.js) which handles URLs correctly.