### PR TITLE
fix(recipient-suggestions): increase debounce time a lot

### DIFF
--- a/src/components/Common/SuggestionField.js
+++ b/src/components/Common/SuggestionField.js
@@ -6,7 +6,7 @@ import { debounce } from '../../utils/helpers.js'
 import i18n from '@dhis2/d2-i18n'
 import * as api from '../../api/api.js'
 
-const searchDelay = 300
+const searchDelay = 1200
 const minCharLength = 2
 
 /*


### PR DESCRIPTION
I experimented with this quite a bit and found this:
- The `300` ms we had was way too short
- When typing a name at a fairly normal pace `800` ms seemed like a pretty reliable time to debounce the request. 
- However, after going into grandad-mode and typing pretty slowly I saw multiple requests had been sent whilst I was typing, so I increased it to `1200` ms. Even at granddad typing speed this seemed to only produce a single request, and I don't think the UI had started to feel unresponsive yet.